### PR TITLE
CoT Prompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 ANTHROPIC_API_KEY="YOUR API KEY"
 OPENAI_API_KEY="YOUR API KEY"
-TAVILY_API_KEY="YOUR API KEY"
+TAVILY_API_KEY="YOUR API KEY" #Optional. Search in the internet.
 
 # Management
 ENVIRONMENT=development
-LOGGING_LEVEL=debug
-PROJECT_ROOT_PATH=/home/lasantoneta/react-component-engineer
-PROMPT_ROOT_PATH=/home/lasantoneta/react-component-engineer
-OUTPUT_CODE_FORMAT=XML
+LOGGING_LEVEL=debug #debug for getting debug information.
+PROJECT_ROOT_PATH=/home/lasantoneta/react-component-engineer #Path to the project root you want to analyze
+PROMPT_ROOT_PATH=/home/lasantoneta/react-component-engineer #Path to the prompt.log file that is generated with the prompt
+OUTPUT_CODE_FORMAT=XML #XML or DASHED_MARKERS
+CHAIN_OF_THOUGHT=true #true or false.

--- a/src/apps/console/classes/commands/prompt.py
+++ b/src/apps/console/classes/commands/prompt.py
@@ -41,6 +41,7 @@ PROCESSED_CONTENT: Dict[Path, Set[int]] = {}
 ALIAS_MAPPING: Dict[str, str] = {}
 DEFAULT_PROMPT_LOG_NAME: str = "prompt.log"
 DEFAULT_OUTPUT_FORMAT: str | None = get_config_value("OUTPUT_CODE_FORMAT", None)
+DEFAULT_CHAIN_OF_THOUGHT: bool | None = get_config_value("CHAIN_OF_THOUGHT", "false") == "true" if get_config_value("CHAIN_OF_THOUGHT", None) else None
 
 
 class PromptConstructorCommand(BaseCommand):
@@ -84,7 +85,10 @@ class PromptConstructorCommand(BaseCommand):
             or "differences"
         )
 
-        is_chain_of_thought: bool = await get_yes_no_bool_user_input(console_message="Use CoT?", default_value="yes")
+        is_chain_of_thought: bool = DEFAULT_CHAIN_OF_THOUGHT
+
+        if DEFAULT_CHAIN_OF_THOUGHT is None:
+            is_chain_of_thought: bool = await get_yes_no_bool_user_input(console_message="Use CoT?", default_value="yes")
 
         self.output_format = await self.get_output_format()
 

--- a/src/apps/console/classes/commands/prompt.py
+++ b/src/apps/console/classes/commands/prompt.py
@@ -5,9 +5,9 @@ import re
 
 
 from src.apps.console.classes.commands.base import BaseCommand
-from src.libs.helpers.console import get_user_input
+from src.libs.helpers.console import get_user_input, get_yes_no_bool_user_input
 from src.libs.utils.string import wrap_text, remove_non_printable_characters, write_indented_content
-from src.libs.utils.constants import CODE_CHANGES, ENTIRE_FILE, DASHED_MARKERS_EXPLANATION, XML_MARKERS_EXPLANATION
+from src.libs.utils.constants import CODE_CHANGES, ENTIRE_FILE, DASHED_MARKERS_EXPLANATION, XML_MARKERS_EXPLANATION, CHAIN_OF_THOUGHT
 from src.libs.utils.prompting import create_dashed_filename_marker, create_dashed_filename_end_marker, update_content_dashed_marker
 from src.libs.utils.file_system import (
     copy_to_clipboard,
@@ -84,6 +84,8 @@ class PromptConstructorCommand(BaseCommand):
             or "differences"
         )
 
+        is_chain_of_thought: bool = await get_yes_no_bool_user_input(console_message="Use CoT?", default_value="yes")
+
         self.output_format = await self.get_output_format()
 
         with open(prompt_log, "w+") as log_file:
@@ -125,6 +127,9 @@ class PromptConstructorCommand(BaseCommand):
                 instructions: str = await self.get_instructions() + "\n"
 
                 write_log_file(log_file, write_indented_content(wrap_text(instructions)))
+
+                if is_chain_of_thought:
+                    write_log_file(log_file, write_indented_content(wrap_text(CHAIN_OF_THOUGHT)))
 
                 if entire_file_vs_code_differences == "differences":
                     instructions_content: str = wrap_text(CODE_CHANGES)
@@ -168,6 +173,9 @@ class PromptConstructorCommand(BaseCommand):
                 instructions: str = await self.get_instructions() + "\n"
 
                 write_log_file(log_file, write_indented_content(wrap_text(instructions)))
+
+                if is_chain_of_thought:
+                    write_log_file(log_file, write_indented_content(wrap_text(CHAIN_OF_THOUGHT)) + "\n\n")
 
                 if entire_file_vs_code_differences == "differences":
                     instructions_content: str = wrap_text(CODE_CHANGES)

--- a/src/libs/helpers/console.py
+++ b/src/libs/helpers/console.py
@@ -68,3 +68,9 @@ async def get_user_input(prompt: str, choices: Optional[List[str]] = None, defau
         return await session.prompt_async(message, multiline=multiline, key_bindings=kb, wrap_lines=True)
     except KeyboardInterrupt:
         raise
+
+
+async def get_yes_no_bool_user_input(console_message: str, default_value: str) -> bool:
+    yes_no: str = await get_user_input(console_message, choices=["yes", "no"], default=default_value) or default_value
+
+    return yes_no == "yes"

--- a/src/libs/utils/configuration.py
+++ b/src/libs/utils/configuration.py
@@ -12,6 +12,7 @@ def get_config() -> Dict[str, Optional[str]]:
         "PROJECT_ROOT_PATH": os.getenv("PROJECT_ROOT_PATH"),
         "PROMPT_ROOT_PATH": os.getenv("PROMPT_ROOT_PATH"),
         "OUTPUT_CODE_FORMAT": os.getenv("OUTPUT_CODE_FORMAT"),
+        "CHAIN_OF_THOUGHT": os.getenv("CHAIN_OF_THOUGHT"),
     }
 
 

--- a/src/libs/utils/constants.py
+++ b/src/libs/utils/constants.py
@@ -222,18 +222,16 @@ declare module '*.module.css' {
 CODE_CHANGES: str = """
 Only show me code changes with a clear indication of where they should be placed.
 
-Take your time to give an answer, and think deeply before answering. Draw a first conclusion, 
-analize your own conclusion and improve it.
 """
 
 ENTIRE_FILE: str = """
 Please, output the modified files with the changes added to it, so I can copy paste it into my codebase.
 
-If you cannot output the entire file with the modified changes due to your own limitations, please respond: "I cannot output the
-entire file with the changes because it's size is exceding my context window."
+If you cannot output the entire file with the modified changes due to your own limitations, please respond with:
+<CONTEXT_WINDOW_EXCEEDED>
 
-Take your time to give an answer, and think deeply before answering. Draw a first conclusion,
-analize your own conclusion and improve it.
+Ensure only <CONTEXT_WINDOW_EXCEEDED> is in the response and nothing else.
+
 """
 
 CLAUDE_CONTEXT_WINDOW: int = 200000
@@ -267,4 +265,8 @@ For example:
     </document_content>
   </document>
 </documents>
+"""
+
+CHAIN_OF_THOUGHT: str = """
+Let's think step-by-step on how to solve this problem. Output your thinking process between <thinking> tags, and the solution between <answer> tags.
 """


### PR DESCRIPTION
I've added two new features:

1. Possibility of add CoT prompt as an .ENV variable. The variable is CHAIN_OF_THOUGHT and can be true or false. If it's set to true or false, the console won't prompt the user to know if she wants CoT in the output prompt. Instead, it's gonna use the default .ENV value set.
2. When the CHAIN_OF_THOUGHT .ENV variable is not set, then the console will prompt to the user to know if she wants CoT in the output prompt or not.

This is the CoT Prompt I've added:

"Let's think step-by-step on how to solve this problem. Output your thinking process between <thinking> tags, and the solution between <answer> tags"